### PR TITLE
specified using ARC in pod spec

### DIFF
--- a/JDDroppableView.podspec
+++ b/JDDroppableView.podspec
@@ -10,6 +10,8 @@ Pod::Spec.new do |s|
   s.license      = "MIT"  
   s.author       = { "Markus Emrich" => "markus@nxtbgthng.com" }  
   
+  s.requires_arc = true
+
   s.source       = { :git => "https://github.com/jaydee3/JDDroppableView.git", :tag => "pod-1.1.0" }  
   s.source_files = 'Library/DroppableView/**/*.{h,m}'  
   


### PR DESCRIPTION
By default this flag is false. So if you have updated you project to use ARC it should be specified in podspec too.
