### PR TITLE
Track intersection frame using UIWindow frame

### DIFF
--- a/Library/DroppableView/JDDroppableView.m
+++ b/Library/DroppableView/JDDroppableView.m
@@ -153,9 +153,10 @@
 	
     // check target contact
     if (self.dropTargets.count > 0) {
+        UIView *rootView = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+        CGRect viewRectInWindow = [self convertRect:self.bounds toView:rootView];
         for (UIView *dropTarget in self.dropTargets) {
-            CGRect viewRectInWindow = [self convertRect:self.frame toView:nil];
-            CGRect dropTargetRectInWindow = [dropTarget convertRect:dropTarget.frame toView:nil];
+            CGRect dropTargetRectInWindow = [dropTarget convertRect:dropTarget.bounds toView:rootView];
             CGRect intersect = CGRectIntersection(viewRectInWindow, dropTargetRectInWindow);
             BOOL didHitTarget = intersect.size.width > 10 || intersect.size.height > 10;
             


### PR DESCRIPTION
Allow drop target view to be in another view subview instead of the
same subviews sibling as the scrollview.

Allow rect intersect tracking to be done on UIWindow frame instead of view frame (Which will not give correct result if the drop view is nested as subviews of another view)
